### PR TITLE
Remove property type for PHP 7.3 - production.

### DIFF
--- a/app/Services/News/StoreService.php
+++ b/app/Services/News/StoreService.php
@@ -10,7 +10,8 @@ class StoreService extends Service
 {
     use SelfCallingService;
 
-    private News $news;
+    /** @var \App\Models\News */
+    private $news;
 
     /**
      * Construct a new StoreService.


### PR DESCRIPTION
- Remove property type for PHP 7.3 in production.