### PR TITLE
Remove property type to work with PHP 7.3

### DIFF
--- a/app/Services/Admin/Post/Api/StoreService.php
+++ b/app/Services/Admin/Post/Api/StoreService.php
@@ -13,7 +13,8 @@ class StoreService extends Service
 {
     use SelfCallingService;
 
-    private Post $posts;
+    /** @var \App\Models\Post */
+    private $posts;
 
     /** @var \App\Services\Admin\Post\Api\StoreValidationService */
     protected $validator;


### PR DESCRIPTION
- Remove property type to work with PHP 7.3